### PR TITLE
Make resources in third AZ optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+Unreleased
+==========
+* Support different AZ counts.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "public_subnets" {
-  value = "${aws_cloudformation_stack.vpc.outputs["PublicSubnet1"]},${aws_cloudformation_stack.vpc.outputs["PublicSubnet2"]},${aws_cloudformation_stack.vpc.outputs["PublicSubnet3"]}"
+  value = "${join(",", compact(split(",", "${aws_cloudformation_stack.vpc.outputs["PublicSubnet1"]},${aws_cloudformation_stack.vpc.outputs["PublicSubnet2"]},${aws_cloudformation_stack.vpc.outputs["PublicSubnet3"]}")))}"
 }
 
 output "public_subnet_1" {
@@ -15,7 +15,7 @@ output "public_subnet_3" {
 }
 
 output "private_subnets" {
-  value = "${aws_cloudformation_stack.vpc.outputs["PrivateSubnet1"]},${aws_cloudformation_stack.vpc.outputs["PrivateSubnet2"]},${aws_cloudformation_stack.vpc.outputs["PrivateSubnet3"]}"
+  value = "${join(",", compact(split(",", "${aws_cloudformation_stack.vpc.outputs["PrivateSubnet1"]},${aws_cloudformation_stack.vpc.outputs["PrivateSubnet2"]},${aws_cloudformation_stack.vpc.outputs["PrivateSubnet3"]}")))}"
 }
 
 output "private_subnet_1" {
@@ -35,7 +35,7 @@ output "spare_subnet_1" {
 }
 
 output "spare_subnets" {
-  value = "${aws_cloudformation_stack.vpc.outputs["SpareSubnet1"]},${aws_cloudformation_stack.vpc.outputs["SpareSubnet2"]},${aws_cloudformation_stack.vpc.outputs["SpareSubnet3"]}"
+  value = "${join(",", compact(split(",", "${aws_cloudformation_stack.vpc.outputs["SpareSubnet1"]},${aws_cloudformation_stack.vpc.outputs["SpareSubnet2"]},${aws_cloudformation_stack.vpc.outputs["SpareSubnet3"]}")))}"
 }
 
 output "spare_subnet_2" {

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,7 @@ Parameters:
     Type: String
 
   AvailabilityZone3:
+    Default: ''
     Type: String
 
   EnvName:
@@ -22,6 +23,9 @@ Parameters:
 Conditions:
   IsActive:
     !Equals [true, !Ref Active]
+
+  AvailabilityZone3Exists:
+    !Not [!Equals [!Ref AvailabilityZone3, '']]
 
 Mappings:
 
@@ -136,6 +140,7 @@ Resources:
       SubnetId: !Ref PublicSubnet2
 
   PublicSubnet3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::Subnet'
     DependsOn: 'Vpc'
     Properties:
@@ -149,6 +154,7 @@ Resources:
           Value: !Join ['', [ !Ref EnvName, ' Public ',  !Ref 'AWS::Region', !Ref AvailabilityZone3 ]]
 
   PublicRouteAssociation3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::SubnetRouteTableAssociation'
     Properties:
       RouteTableId: !Ref PublicRouteTable
@@ -221,6 +227,7 @@ Resources:
       SubnetId: !Ref PrivateSubnet2
 
   PrivateSubnet3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::Subnet'
     DependsOn: 'Vpc'
     Properties:
@@ -233,6 +240,7 @@ Resources:
           Value: !Join ['', [ !Ref EnvName, ' Private ',  !Ref 'AWS::Region', !Ref AvailabilityZone3 ]]
 
   PrivateRouteAssociation3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::SubnetRouteTableAssociation'
     Properties:
       RouteTableId: !Ref PrivateRouteTable
@@ -275,6 +283,7 @@ Resources:
       SubnetId: !Ref SpareSubnet2
 
   SpareSubnet3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::Subnet'
     DependsOn: 'Vpc'
     Properties:
@@ -287,6 +296,7 @@ Resources:
           Value: !Join ['', [ !Ref EnvName, ' Spare ',  !Ref 'AWS::Region', !Ref AvailabilityZone3 ]]
 
   SpareRouteAssociation3:
+    Condition: 'AvailabilityZone3Exists'
     Type: 'AWS::EC2::SubnetRouteTableAssociation'
     Properties:
       RouteTableId: !Ref PublicRouteTable
@@ -299,21 +309,21 @@ Outputs:
   PublicSubnet2:
     Value: !Ref PublicSubnet2
   PublicSubnet3:
-    Value: !Ref PublicSubnet3
+    Value: !If [AvailabilityZone3Exists, !Ref PublicSubnet3, '']
 
   PrivateSubnet1:
     Value: !Ref PrivateSubnet1
   PrivateSubnet2:
     Value: !Ref PrivateSubnet2
   PrivateSubnet3:
-    Value: !Ref PrivateSubnet3
+    Value: !If [AvailabilityZone3Exists, !Ref PrivateSubnet3, '']
 
   SpareSubnet1:
     Value: !Ref SpareSubnet1
   SpareSubnet2:
     Value: !Ref SpareSubnet2
   SpareSubnet3:
-    Value: !Ref SpareSubnet3
+    Value: !If [AvailabilityZone3Exists, !Ref SpareSubnet3, '']
 
   VpcId:
     Value: !Ref Vpc

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,8 @@ variable "active" {
 }
 variable "az1" {}
 variable "az2" {}
-variable "az3" {}
+variable "az3" {
+  default = ""
+}
 variable "env" {}
 variable "name" {}


### PR DESCRIPTION
Not all regions in all accounts have three AZs.

@dylanvaughn I'm not super happy with how the CF outputs pass in to the terraform outputs but couldn't come up with a cleaner way. Everything else I tried ended with the terraform outputs being empty and CF blowing up on validation. If you have any other ideas let me know. Worked in Norm's account.